### PR TITLE
Fix bug in example code

### DIFF
--- a/root/main.py
+++ b/root/main.py
@@ -3,7 +3,7 @@ from .webdriver_util import init
 
 def query_google(keywords):
     print("Loading Firefox driver...")
-    driver, waiter, selector = init()
+    driver, waiter, selector, datapath = init()
 
     print("Fetching google front page...")
     driver.get("http://google.com")


### PR DESCRIPTION
Fixes:
line 6, in query_google
    driver, waiter, selector = init()
ValueError: too many values to unpack (expected 3)